### PR TITLE
Issue #11 safe half: zod v4 z.record + test-utils Session + jest-mock any→never

### DIFF
--- a/AssistantAPP-main/__tests__/agents/invoke.test.ts
+++ b/AssistantAPP-main/__tests__/agents/invoke.test.ts
@@ -15,11 +15,15 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 // Mock Prisma + audit + ai-router BEFORE importing the runtime.
 jest.mock('@/lib/db', () => ({
   getPrisma: async () => ({
-    automationLog: { create: jest.fn().mockResolvedValue({} as any) },
+    // `as never` is the jest-mock v30 workaround: `jest.fn()` with no
+    // explicit generic infers `(...args: never) => never`, so the
+    // mockResolvedValue slot is typed `never` and `as any` fails
+    // "any is not assignable to never". Issue #11 §4.
+    automationLog: { create: jest.fn().mockResolvedValue({} as never) },
   }),
 }))
 jest.mock('@/lib/audit', () => ({
-  logAuditEvent: jest.fn().mockResolvedValue(undefined as any),
+  logAuditEvent: jest.fn().mockResolvedValue(undefined as never),
 }))
 jest.mock('@/lib/ai-router', () => {
   const actual = jest.requireActual('@/lib/ai-router') as any
@@ -34,7 +38,7 @@ jest.mock('@/lib/ai-router', () => {
   }
 })
 jest.mock('@/lib/events', () => ({
-  dispatch: jest.fn().mockResolvedValue([] as any),
+  dispatch: jest.fn().mockResolvedValue([] as never),
 }))
 
 import * as breaker from '@/lib/agents/breaker'

--- a/AssistantAPP-main/__tests__/lib-audit.test.ts
+++ b/AssistantAPP-main/__tests__/lib-audit.test.ts
@@ -16,7 +16,9 @@ describe('lib/audit — logAuditEvent', () => {
   })
 
   it('writes to prisma.auditLog.create with canonical field names', async () => {
-    const create = jest.fn().mockResolvedValue({ id: 'a1' } as any)
+    // `as never` — jest-mock v30 types the mockResolvedValue slot
+    // as `never` when `jest.fn()` has no explicit generic. Issue #11 §4.
+    const create = jest.fn().mockResolvedValue({ id: 'a1' } as never)
     jest.doMock('@/lib/db', () => ({
       getPrisma: async () => ({ auditLog: { create } }),
     }))
@@ -39,7 +41,9 @@ describe('lib/audit — logAuditEvent', () => {
   it('swallows DB errors (non-fatal audit policy)', async () => {
     jest.doMock('@/lib/db', () => ({
       getPrisma: async () => ({
-        auditLog: { create: jest.fn().mockRejectedValue(new Error('pg down')) },
+        auditLog: {
+          create: jest.fn().mockRejectedValue(new Error('pg down') as never),
+        },
       }),
     }))
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -49,7 +53,7 @@ describe('lib/audit — logAuditEvent', () => {
   })
 
   it('legacy logAudit(prisma, entry) signature still works', async () => {
-    const create = jest.fn().mockResolvedValue({} as any)
+    const create = jest.fn().mockResolvedValue({} as never)
     jest.doMock('@/lib/db', () => ({
       getPrisma: async () => ({ auditLog: { create } }),
     }))

--- a/AssistantAPP-main/agents/drafting/schema.ts
+++ b/AssistantAPP-main/agents/drafting/schema.ts
@@ -5,7 +5,7 @@ export const DraftingInputSchema = z.object({
   leadId: z.string().optional(),
   templateId: z.string().min(1),
   channel: z.enum(['email', 'whatsapp', 'portal', 'letter', 'internal']),
-  variables: z.record(z.string()),
+  variables: z.record(z.string(), z.string()),
   // D-015 · D-019 — locale is multi-valued from v1. AR drafting requires a
   // native AR reviewer in marketing-HITL per D-015 before client send.
   locale: z.enum(['en', 'ar', 'pt']).default('en'),

--- a/AssistantAPP-main/agents/intake/schema.ts
+++ b/AssistantAPP-main/agents/intake/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 export const IntakeInputSchema = z.object({
   leadId:  z.string().min(1),
-  answers: z.record(z.unknown()),
+  answers: z.record(z.string(), z.unknown()),
   attachments: z
     .array(z.object({
       gcsKey: z.string(),

--- a/AssistantAPP-main/docs/EXECUTION_LOG.md
+++ b/AssistantAPP-main/docs/EXECUTION_LOG.md
@@ -1087,6 +1087,99 @@ rebased onto the result. Resolved conflicts:
 
 ---
 
+## 2026-04-23 · Issue #11 safe half — zod v4 `z.record`, test-utils Session shape, jest-mock `any → never`
+
+Branch: `claude/issue-11-safe-half-9qrP3`.
+
+Closes the "safe" subset of Issue #11 (the 41 pre-existing TS
+errors that keep `legacy-checks` informational). Scope: **zod v4
+`z.record`** (2 errors), **test-utils Session shape** (1 error),
+**jest-mock `any → never`** in `invoke.test.ts` + `lib-audit.test.ts`
+(6 errors). Total: 9 errors eliminated; ~32 remain on the
+"risky half" (recharts React type drift, `lib/agents/invoke.ts`
+generics, `@prisma/client` enum re-exports + the three dependent
+miscellaneous errors in `service-types.test.ts`).
+
+**Code.**
+
+- `agents/intake/schema.ts` — `z.record(z.unknown())` →
+  `z.record(z.string(), z.unknown())`. Zod v4 requires an explicit
+  key schema for `z.record`.
+- `agents/drafting/schema.ts` — `z.record(z.string())` →
+  `z.record(z.string(), z.string())`. Same fix.
+- `test-utils/testUtils.tsx` — mock `Session` now carries `id`
+  (missing before) and the role literal is uppercased (`'admin'`
+  → `'ADMIN'` per the `Role` enum in `prisma/schema.prisma`). The
+  role is typed via `Session['user']['role']` rather than by
+  importing `Role` directly from `@prisma/client` — that direct
+  import is exactly the enum-re-export gap tracked as the Issue
+  #11 risky half. Routing through `Session['user']['role']`
+  resolves to the same `Role` type at the type-level (from
+  `types/next-auth.d.ts`) without adding a runtime dependency on
+  the generated client. Inline comment documents the choice.
+- `__tests__/agents/invoke.test.ts` — 3 × `as any` → `as never` on
+  `mockResolvedValue(...)` calls (for `automationLog.create`,
+  `logAuditEvent`, `events.dispatch`). `jest.fn()` with no
+  explicit generic infers `(...args: never) => never` under
+  `@jest/globals` v30, so the mockResolvedValue slot is typed
+  `never`. `as any` was the pre-existing workaround but now fails
+  "any not assignable to never"; `as never` is the team-convention
+  fix. One inline comment at the first site explains the pattern.
+- `__tests__/lib-audit.test.ts` — 3 × same pattern on
+  `auditLog.create` mocks: `as any` → `as never` on
+  `mockResolvedValue({ id: 'a1' } as never)`,
+  `mockRejectedValue(new Error('pg down') as never)` (the `new
+  Error(...)` slot hits the same never-typed parameter), and
+  `mockResolvedValue({} as never)`.
+
+**Not touched (explicitly deferred to the risky half).**
+
+- `__tests__/service-types.test.ts` — the issue lists it as having
+  3 jest-mock errors, but the `mockResolvedValue({ user: { id,
+  role } })` calls go through `(getServerSession as
+  jest.MockedFunction<typeof getServerSession>).mockResolvedValue(...)`,
+  which types the argument as `Session | null`. The failure there
+  is **not** `any → never` — it's a Session-shape mismatch caused
+  by the session literal missing `email`/`name`/`expires` and the
+  `role: 'STAFF'` string not matching the `Role` enum type. Fixing
+  it cleanly needs the Prisma enum re-export landed first, so
+  it's in the risky half.
+- `components/dashboard/*` (recharts React type drift),
+  `lib/agents/invoke.ts` (generic inference),
+  `lib/auth.ts` / `lib/auth/options.ts` / `prisma/seed.ts`
+  (`@prisma/client` enum re-exports), and the miscellaneous
+  `app/notifications/page.tsx` / `BillingDashboard.tsx:329`
+  errors.
+
+**Docs.**
+
+- `docs/EXECUTION_LOG.md` — this entry. No `D-NNN` — none of the
+  changes are architectural.
+- No `EXECUTION_PLAN.md` edit — §10.x sprint recipes unchanged.
+  A-010-R2 version-bump gate doesn't fire.
+
+**CI impact.** 9 of the 41 TS errors that keep `legacy-checks` at
+`continue-on-error: true` are now resolved. `npx tsc --noEmit` is
+still red on the risky half, so `legacy-checks` stays informational
+until that lands. A follow-up PR picks up the remaining ~32,
+starting with the Prisma enum re-export (which unblocks both the
+service-types test fixes and the lib/auth cleanup).
+
+**Exit criteria (this PR).** The five edited files pass
+`tsc --noEmit` individually (where "individually" means in
+isolation from the risky-half failures in other files).
+
+**Deferred.**
+
+- Issue #11 risky half — `@prisma/client` enum re-export (unblocks
+  `service-types.test.ts` + `lib/auth.ts` + `prisma/seed.ts`),
+  `@types/react` override for recharts, `lib/agents/invoke.ts`
+  generic cast, misc response-type fixes. Separate PR; probably
+  needs its own audit at the end (re-run `tsc --noEmit` on `main`,
+  confirm zero, flip `legacy-checks` to blocking).
+
+---
+
 ## Rolling open items
 
 Copied from the commits above; delete lines here as they land.

--- a/AssistantAPP-main/test-utils/testUtils.tsx
+++ b/AssistantAPP-main/test-utils/testUtils.tsx
@@ -1,15 +1,23 @@
 import { render, RenderOptions } from '@testing-library/react'
 import { ReactElement } from 'react'
 import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
 
-// Mock session for testing
-const mockSession = {
+// Mock session for testing. `types/next-auth.d.ts` augments Session
+// with `user.id: string` and `user.role: Role`. The `Role` enum is
+// imported there as a type — re-importing it here (or from the
+// generated `@prisma/client`) hits the enum re-export gap tracked
+// as the "risky half" of Issue #11. So we route the role literal
+// through `Session['user']['role']` instead, which resolves to the
+// same `Role` type without needing the runtime import.
+const mockSession: Session = {
   user: {
+    id: 'test-user-1',
     email: 'test@example.com',
-    role: 'admin',
-    name: 'Test User'
+    role: 'ADMIN' as Session['user']['role'],
+    name: 'Test User',
   },
-  expires: '2024-12-31'
+  expires: '2024-12-31',
 }
 
 // Custom render function that includes providers


### PR DESCRIPTION
Closes **Issue #11** (the safe subset). 9 of the 41 pre-existing TS errors resolved — the ones that don't depend on the Prisma enum re-export. Leaves ~32 errors on the risky half, which needs its own PR.

~122 LOC across 5 code files + 1 doc file. No D-NNN, no EXECUTION_PLAN edit.

## What's fixed

| Class | Files | Fix |
|-------|-------|-----|
| **Zod v4 `z.record`** (2 errors) | `agents/intake/schema.ts`, `agents/drafting/schema.ts` | `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`; `z.record(z.string())` → `z.record(z.string(), z.string())`. Zod v4 requires an explicit key schema. |
| **Session shape** (1 error) | `test-utils/testUtils.tsx` | Add `id: 'test-user-1'` to mock user; uppercase `'admin'` → `'ADMIN'` per the `Role` enum in `prisma/schema.prisma`; type via `Session` from `next-auth` so augmentation applies; cast role literal via `Session['user']['role']` rather than importing `Role` from `@prisma/client` (that runtime import is exactly the enum-re-export gap — **risky half**). Inline comment documents the choice. |
| **jest-mock `any → never`** (6 errors) | `__tests__/agents/invoke.test.ts` (3), `__tests__/lib-audit.test.ts` (3) | `jest.fn()` with no explicit generic infers `(...args: never) => never` under `@jest/globals` v30; `mockResolvedValue`/`mockRejectedValue` slots are typed `never`. `as any` fails "any not assignable to never"; `as never` is the team-convention fix. One inline comment at the first site explains. |

## What's explicitly *not* fixed (deferred to the risky half)

- **`__tests__/service-types.test.ts`** — Issue #11 lists it as having 3 jest-mock errors, but the failing `mockResolvedValue({ user: { id, role } })` calls go through `(getServerSession as jest.MockedFunction<...>).mockResolvedValue(...)`, which types the argument as `Session | null`. The real failure is a **Session-shape mismatch** (missing `email`/`name`/`expires`, role string vs. `Role` enum), not `any → never`. Fixing it cleanly needs the Prisma enum re-export first.
- `components/dashboard/*` — recharts React type drift (12 errors). Needs `@types/react` override or recharts upgrade.
- `lib/agents/invoke.ts` — generic inference (6 errors). Needs explicit cast at return sites.
- `lib/auth.ts`, `lib/auth/options.ts`, `prisma/seed.ts` — `@prisma/client` enum re-exports (6 errors). Needs prisma-client generator config fix.
- `app/notifications/page.tsx:1`, `BillingDashboard.tsx:329`, `service-types.test.ts` misc (5 errors).

## CI impact

- **`gates · audits` (required)** — unchanged. No audit-script output differs.
- **`legacy-checks · tsc/...` (informational)** — still red (32 TS errors remain), so still informational. Flipping it to blocking is the exit criterion for the risky-half PR that picks up the remaining errors.

## Merge ordering

Independent of PR #14 (pass-2 xrepo review) and PR #15 (Sprint 0.7 infra). No file overlap with either. Merge in any order.

## Test plan

- [ ] `gates` green (expected — no audit-relevant changes).
- [ ] `legacy-checks` → `Type check` step: the edited files no longer contribute to the error count; total TS2345/TS2554/TS2322 count drops by 9. Easiest to verify by downloading the CI job log and diffing against main's pre-existing count.
- [ ] Jest run on `invoke.test.ts` and `lib-audit.test.ts` still passes (out of sandbox — no node_modules here). The `as never` cast is type-level only; runtime behaviour of `mockResolvedValue`/`mockRejectedValue` is unchanged.
- [ ] Hand-run `npx tsc --noEmit agents/intake/schema.ts agents/drafting/schema.ts` in a dev env — should compile clean for those specific files.

Closes the safe subset of #11. The risky-half PR takes it home.

https://claude.ai/code/session_01SsYt689YYVGrjMeS4HRpg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsYt689YYVGrjMeS4HRpg5)_